### PR TITLE
Task/ot 9 patient registration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Once the plugin is installed on the Kong instance, it can be configured via the 
 {
     "name": "health-apis-patient-registration",
     "config": {
-        "ids_url": "{{ids-endpoint}}/api/v1/ids"
-        "token_url": "{{token-endpoint}}'"
+        "ids_url": "{ids-endpoint}/api/v1/ids"
+        "token_url": "{token-endpoint}'"
         "token_timeout": "10000"
-        "static_refresh_token": "{{static-refresh-token}}",
-        "static_icn": "{{static-icn}}"
+        "static_refresh_token": "{static-refresh-token}",
+        "static_icn": "{static-icn}"
     },
     "enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ A Kong plugin to validate a supplied OAuth token.  It can be installed on a Kong
 
 ### Building
 
-> Luarocks must be installed to build.
-
-Run `luarocks pack health-apis-token-validator-0.1-2.rockspec` to package the plugin into a Lua "rock" which can then be copied and installed on a Kong instance.
-
 ### Configuration
 
 Once the plugin is installed on the Kong instance, it can be configured via the Admin port.  Replace config entries with the correct values for your environment.
@@ -38,11 +34,6 @@ Once the plugin is installed on the Kong instance, it can be configured via the 
 
 A Kong plugin to return a static access token used for customer testing
 
-> Luarocks must be installed to build.
-
-Run `luarocks pack health-apis-static-token-handler-0.1-1.rockspec` to package the plugin into a Lua "rock" which can then be copied and installed on a Kong instance.
-
-
 ### Configuration
 
 Once the plugin is installed on the Kong instance, it can be configured via the Admin port.  Replace config entries with the correct values for your environment.
@@ -61,15 +52,34 @@ Once the plugin is installed on the Kong instance, it can be configured via the 
 }
 ```
 
+## health-apis-patient-registration Kong Plugin
+
+A Kong plugin to handle patient registration with the Identity Service as part of the access token retrieval.
+
+
+### Configuration
+
+Once the plugin is installed on the Kong instance, it can be configured via the Admin port.  Replace config entries with the correct values for your environment.
+
+```
+{
+    "name": "health-apis-patient-registration",
+    "config": {
+        "ids_url": "{{ids-endpoint}}/api/v1/ids"
+        "token_url": "{{token-endpoint}}'"
+        "token_timeout": "10000"
+    },
+    "enabled": true
+}
+```
 
 ## Local development
 
-The base Kong docker-compose file has been updated to mount the two plugins as volumes within the Kong docker container.  Along with the `KONG_PLUGINS` config defining the additional plugins as enabled.
+A docker-compose script exists for local development of plugins.  Ensure you first build `docker build -t health-apis-kong:latest .` to test your changes.
+
+`COPY kong/plugins/ /usr/local/share/lua/5.1/kong/plugins/` in the Dockerfile copies the custom plugins into the image.
+
+> Note:  Uncomment `COPY kong.yml /etc/kong/kong.yml` in the Dockerfile to utilize the local kong.yml, otherwise it will pull from S3 and not include your configurations.
 
 `docker-compose up`
 
-Docker must be allowed share access to the location of your local repo.
-
-> Note:   There have been issues observed mounting volumes when logged in to your machine with an Active Directory account
-
-With volume mounting, you can use your local machine's text editor of choice for testing changes of the Lua files.  A simple `kong reload` will update your changes within the kong instance.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Once the plugin is installed on the Kong instance, it can be configured via the 
         "ids_url": "{{ids-endpoint}}/api/v1/ids"
         "token_url": "{{token-endpoint}}'"
         "token_timeout": "10000"
-        "static_refresh_token": "{static-refresh-token}",
-        "static_icn": "{static-icn}"
+        "static_refresh_token": "{{static-refresh-token}}",
+        "static_icn": "{{static-icn}}"
     },
     "enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ Once the plugin is installed on the Kong instance, it can be configured via the 
         "ids_url": "{{ids-endpoint}}/api/v1/ids"
         "token_url": "{{token-endpoint}}'"
         "token_timeout": "10000"
+        "static_refresh_token": "{static-refresh-token}",
+        "static_icn": "{static-icn}"
     },
     "enabled": true
 }
 ```
+
+> Note:  The static patient still needs to register with the Identity Service, so that use case requires the additional config values.
 
 ## Local development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       KONG_DECLARATIVE_CONFIG: /etc/kong/kong.yml
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
-      KONG_PLUGINS: bundled,health-apis-token-validator,health-apis-static-token-handler
+      KONG_PLUGINS: request-termination,response-transformer,health-apis-token-validator,health-apis-static-token-handler,health-apis-patient-registration
       AWS_CONFIG_FOLDER: kong
       AWS_APP_NAME: kong
     ports:

--- a/kong.yml
+++ b/kong.yml
@@ -32,14 +32,11 @@ services:
         static_expiration: 3599
         static_icn: {{static-icn}}
         static_scopes: {{static-scopes}}
-    - name: request-termination
+    - name: health-apis-patient-registration
       config:
-        status_code: 307
-    - name: response-transformer
-      config:
-        add:
-          headers:
-            - 'Location: {{token-endpoint}}'
+        ids_url: {{ids-endpoint}}/api/v1/ids
+        token_url: 'Location: {{token-endpoint}}'
+        token_timeout: 10000
   - name: argonaut-base-api-route
     paths:
     - /api

--- a/kong.yml
+++ b/kong.yml
@@ -37,6 +37,8 @@ services:
         ids_url: {{ids-endpoint}}/api/v1/ids
         token_url: 'Location: {{token-endpoint}}'
         token_timeout: 10000
+        static_refresh_token: {{static-refresh-token}}
+        static_icn: {{static-icn}}
   - name: argonaut-base-api-route
     paths:
     - /api

--- a/kong/plugins/health-apis-patient-registration/handler.lua
+++ b/kong/plugins/health-apis-patient-registration/handler.lua
@@ -1,7 +1,35 @@
 local HealthApisPatientRegistration = require("kong.plugins.base_plugin"):extend()
 
+local http = require "resty.http"
+local cjson = require "cjson.safe"
+
+local find = string.find
+local format = string.format
+
+local OPERATIONAL_OUTCOME_TEMPLATE =
+  '{ "resourceType": "OperationOutcome",\n' ..
+  '  "id": "exception",\n' ..
+  '  "text": {\n' ..
+  '      "status": "additional",\n' ..
+  '      "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><p>%s</p></div>"\n' ..
+  '  },\n' ..
+  '  "issue": [\n' ..
+  '      {\n' ..
+  '          "severity": "error",\n' ..
+  '          "code": "exception",\n' ..
+  '          "details": {\n' ..
+  '              "text": "%s"\n' ..
+  '          }\n' ..
+  '      }\n' ..
+  '  ]\n' ..
+  '}'
+
+local BAD_AUTHORIZE_RESPONSE = "Authorization failed."
+local BAD_IDS_RESPONSE = "IDS failed."
+
+
 function HealthApisPatientRegistration:new()
-  HealthApisPatientRegistration.super.new(self, "health-apis-static-token-handler")
+  HealthApisPatientRegistration.super.new(self, "health-apis-patient-registration")
 end
 
 function HealthApisPatientRegistration:access(conf)
@@ -17,24 +45,112 @@ function HealthApisPatientRegistration:access(conf)
   -- Required by lua (request body data not loaded by default)
   ngx.req.read_body()
 
-  local body, errors = ngx.req.get_post_args()
+  local body_data, errors = ngx.req.get_body_data()
 
   if errors == "truncated" then
     -- one can choose to ignore or reject the current request here
   end
 
-  if not body then
+  if not body_data then
     ngx.log(ngx.ERR, "failed to get post args: ", errors)
     return
   end
+    
+  local client = http.new()
+  client:set_timeout(self.conf.token_timeout)
+    
+  local token_res, err = client:request_uri(self.conf.token_url, {
+    method = "POST",
+    ssl_verify = false,
+    headers = {
+      ["Content-Type"] = "application/x-www-form-urlencoded",
+    },
+    body = body_data,
+  })
+  
+  if not token_res then
+    -- Error making request to validate endpoint
+    return self:send_fhir_response(404, BAD_AUTHORIZE_RESPONSE)
+  end
 
-  --Retrieve ICN
-  --Register with IDS
+  -- Get the status and body of the token request
+  -- So we can be done with the connection
+  local token_res_status = token_res.status
+  local token_res_body = token_res.body
 
+  -- If unauthorized, we block the user
+  if (token_res_status == 401) then
+    return self:send_fhir_response(401, BAD_AUTHORIZE_RESPONSE)
+  end
+
+  -- An unexpected condition
+  if (token_res_status < 200 or token_res_status > 299) then
+    return self:send_fhir_response(500, BAD_AUTHORIZE_RESPONSE)
+  end
+
+  local token_res_json = cjson.decode(token_res_body)      
+  self:register_patient(token_res_json.patient)
+  
+  return self:send_response(token_res_status, token_res_body)
+
+end
+
+function HealthApisPatientRegistration:register_patient(patient_icn)
+
+  local ids_client = http.new()
+  ids_client:set_timeout(self.conf.token_timeout)
+  
+  local ids_body_data = '[\n' ..
+    '{\n' ..
+    '    "system": "CDW",\n' ..
+    '    "resource": "PATIENT",\n' ..
+    '    "identifier": "' .. patient_icn .. '"\n' ..
+    '}\n' ..
+    ']'
+  
+  local ids_res, err = ids_client:request_uri(self.conf.ids_url, {
+    method = "POST",
+    ssl_verify = false,
+    headers = {
+      ["Content-Type"] = "application/json",
+    },
+    body = ids_body_data,
+  })
+  
+  if not ids_res then
+    -- Error making request to validate endpoint
+    return self:send_fhir_response(404, BAD_IDS_RESPONSE)
+  end
+
+  -- Get the status and body of the verification request
+  -- So we can be done with the connection
+  local ids_res_status = ids_res.status
+  local ids_res_body = ids_res.body
+
+  -- If unauthorized, we block the user
+  if (ids_res_status == 401) then
+    return self:send_fhir_response(401, BAD_IDS_RESPONSE)
+  end
+
+  -- An unexpected condition
+  if (ids_res_status < 200 or ids_res_status > 299) then
+    return self:send_fhir_response(500, BAD_IDS_RESPONSE)
+  end
+  
 end
 
 
 -- Format and send the response to the client
+function HealthApisPatientRegistration:send_fhir_response(status_code, message)
+
+  ngx.status = status_code
+  ngx.header["Content-Type"] = "application/json"
+
+  ngx.say(format(OPERATIONAL_OUTCOME_TEMPLATE, message, message))
+
+  ngx.exit(status_code)
+end
+
 function HealthApisPatientRegistration:send_response(status_code, message)
 
   ngx.status = status_code

--- a/kong/plugins/health-apis-patient-registration/handler.lua
+++ b/kong/plugins/health-apis-patient-registration/handler.lua
@@ -55,6 +55,16 @@ function HealthApisPatientRegistration:access(conf)
     ngx.log(ngx.ERR, "failed to get post args: ", errors)
     return
   end
+  
+  local post_args, errors = ngx.req.get_post_args()
+  local requestRefreshToken = post_args["refresh_token"]  
+  
+  if (requestRefreshToken ~= nil and requestRefreshToken == self.conf.static_refresh_token) then
+    ngx.log(ngx.INFO, "Static refresh token requested")
+    self:register_patient(self.conf.static_icn)
+    --only register the static patient, no token call required
+    return
+  end
     
   local client = http.new()
   client:set_timeout(self.conf.token_timeout)
@@ -165,6 +175,6 @@ function HealthApisPatientRegistration:send_response(status_code, message)
 end
 
 
-HealthApisPatientRegistration.PRIORITY = 1009
+HealthApisPatientRegistration.PRIORITY = 1011
 
 return HealthApisPatientRegistration

--- a/kong/plugins/health-apis-patient-registration/handler.lua
+++ b/kong/plugins/health-apis-patient-registration/handler.lua
@@ -1,0 +1,50 @@
+local HealthApisPatientRegistration = require("kong.plugins.base_plugin"):extend()
+
+function HealthApisPatientRegistration:new()
+  HealthApisPatientRegistration.super.new(self, "health-apis-static-token-handler")
+end
+
+function HealthApisPatientRegistration:access(conf)
+  HealthApisPatientRegistration.super.access(self)
+
+  self.conf = conf
+
+  if (self.conf.ids_url == nil) then
+    ngx.log(ngx.ERR, "IDS URL not set.")
+    return
+  end
+
+  -- Required by lua (request body data not loaded by default)
+  ngx.req.read_body()
+
+  local body, errors = ngx.req.get_post_args()
+
+  if errors == "truncated" then
+    -- one can choose to ignore or reject the current request here
+  end
+
+  if not body then
+    ngx.log(ngx.ERR, "failed to get post args: ", errors)
+    return
+  end
+
+  --Retrieve ICN
+  --Register with IDS
+
+end
+
+
+-- Format and send the response to the client
+function HealthApisPatientRegistration:send_response(status_code, message)
+
+  ngx.status = status_code
+  ngx.header["Content-Type"] = "application/json"
+  ngx.say(message)
+  ngx.exit(status_code)
+  
+end
+
+
+HealthApisPatientRegistration.PRIORITY = 1010
+
+return HealthApisPatientRegistration

--- a/kong/plugins/health-apis-patient-registration/handler.lua
+++ b/kong/plugins/health-apis-patient-registration/handler.lua
@@ -26,7 +26,7 @@ local OPERATIONAL_OUTCOME_TEMPLATE =
 
 local BAD_AUTHORIZE_RESPONSE = "Authorization failed."
 local BAD_IDS_RESPONSE = "IDS failed."
-
+local MISSING_ICN = "Token response missing ICN."
 
 function HealthApisPatientRegistration:new()
   HealthApisPatientRegistration.super.new(self, "health-apis-patient-registration")
@@ -97,6 +97,10 @@ end
 
 function HealthApisPatientRegistration:register_patient(patient_icn)
 
+  if (patient_icn == nil) then
+    return self:send_fhir_response(500, MISSING_ICN)
+  end
+
   local ids_client = http.new()
   ids_client:set_timeout(self.conf.token_timeout)
   
@@ -161,6 +165,6 @@ function HealthApisPatientRegistration:send_response(status_code, message)
 end
 
 
-HealthApisPatientRegistration.PRIORITY = 1010
+HealthApisPatientRegistration.PRIORITY = 1009
 
 return HealthApisPatientRegistration

--- a/kong/plugins/health-apis-patient-registration/handler.lua
+++ b/kong/plugins/health-apis-patient-registration/handler.lua
@@ -47,10 +47,6 @@ function HealthApisPatientRegistration:access(conf)
 
   local body_data, errors = ngx.req.get_body_data()
 
-  if errors == "truncated" then
-    -- one can choose to ignore or reject the current request here
-  end
-
   if not body_data then
     ngx.log(ngx.ERR, "failed to get post args: ", errors)
     return

--- a/kong/plugins/health-apis-patient-registration/schema.lua
+++ b/kong/plugins/health-apis-patient-registration/schema.lua
@@ -1,6 +1,8 @@
 return {
   no_consumer = true,
   fields = {
-    ids_url = {type = "string"}
+    ids_url = {type = "string"},
+    token_url = {type = "string"},
+    token_timeout = {type = "number", default = 10000},
   }
 }

--- a/kong/plugins/health-apis-patient-registration/schema.lua
+++ b/kong/plugins/health-apis-patient-registration/schema.lua
@@ -1,0 +1,6 @@
+return {
+  no_consumer = true,
+  fields = {
+    ids_url = {type = "string"}
+  }
+}

--- a/kong/plugins/health-apis-patient-registration/schema.lua
+++ b/kong/plugins/health-apis-patient-registration/schema.lua
@@ -4,5 +4,7 @@ return {
     ids_url = {type = "string"},
     token_url = {type = "string"},
     token_timeout = {type = "number", default = 10000},
+    static_refresh_token = {type = "string", default = ""},
+    static_icn = {type = "string", default = ""},
   }
 }

--- a/kong/plugins/health-apis-static-token-handler/handler.lua
+++ b/kong/plugins/health-apis-static-token-handler/handler.lua
@@ -18,10 +18,6 @@ function HealthApisStaticTokenHandler:access(conf)
 
   local body, errors = ngx.req.get_post_args()
 
-  if errors == "truncated" then
-    -- one can choose to ignore or reject the current request here
-  end
-
   if not body then
     ngx.log(ngx.ERR, "failed to get post args: ", errors)
     return

--- a/kong/plugins/health-apis-token-validator/handler.lua
+++ b/kong/plugins/health-apis-token-validator/handler.lua
@@ -124,7 +124,6 @@ function HealthApisTokenValidator:check_scope(tokenScope)
   local requestedResource = self:get_requested_resource_type()
   local requestScope = "patient/" .. requestedResource .. ".read"
 
-  ngx.log(ngx.ERR, "Requested scope: ", requestScope)
   if (self:check_for_array_entry(tokenScope, requestScope) ~= true) then
     ngx.log(ngx.INFO, "Requested resource scope not granted to token")
     return self:send_response(403, SCOPE_MISMATCH)


### PR DESCRIPTION
JIRA Issue: https://vasdvp.atlassian.net/browse/OT-9

Implemented Patient Registration functionality with the Identity Service.

In order to have access to the Patient ICN, the Kong /token endpoint now handles the calls to the va.gov/oauth2/token endpoint.  The POST result body is still returned to the client as if the 307 redirect was still in place, but the plugin utilizes the ICN to register with the IDS.