### PR TITLE
Updated regex to not require leading slash api in path

### DIFF
--- a/kong/plugins/health-apis-token-validator/handler.lua
+++ b/kong/plugins/health-apis-token-validator/handler.lua
@@ -156,7 +156,7 @@ function HealthApisTokenValidator:get_token_from_auth_string(authString)
 end
 
 function HealthApisTokenValidator:is_request_read()
-  local requestedResourceRead = string.match(ngx.var.uri, "/api/%a*/[%w%-]+$")
+  local requestedResourceRead = string.match(ngx.var.uri, "/%a*/[%w%-]+$")
   return (requestedResourceRead ~= nil)
 end
 


### PR DESCRIPTION
JIRA Issure: https://vasdvp.atlassian.net/browse/API-1240

The leading `/api` is being removed from the path of the different API's.

This PR is to simply remove the leading `/api` from regex used to find if the request is a resource read for scope validation.

Since the regex is anchored to the end of the path string, it does still work with a leading `/api` until the different API versions without the leading `/api` are released.


**Note**: If/When IDS is updated, the IDS endpoint configured for patient registration will need to be updated.  This is a config change only, no new build required.
