### PR TITLE
run-local.sh can now preserve the dev-kong.yaml 

### DIFF
--- a/run-local.sh
+++ b/run-local.sh
@@ -46,16 +46,19 @@ SECRETS=$(pwd)/secrets.conf
 # to run with local applications.
 #
 DEV_CONF=$(pwd)/dev-kong.yaml
-
-(
-  echo "Loading $SECRETS"
-  . $SECRETS
-  cat $SOURCE_CONF | envsubst > $DEV_CONF
-)
-sed -i \
-    -e "s/ids:8082/$HOST_ACCESSIBLE_FROM_WITHIN_DOCKER:8089/" \
-    -e "s/data-query:80/$HOST_ACCESSIBLE_FROM_WITHIN_DOCKER:8090/" \
-    $DEV_CONF
+if [ "${DEV_CONF_KEEP:-false}" == "false" ]
+then
+  (
+    echo "Loading $SECRETS"
+    . $SECRETS
+    echo "Writing $DEV_CONF"
+    cat $SOURCE_CONF | envsubst > $DEV_CONF
+  )
+  sed -i \
+      -e "s/ids:8082/$HOST_ACCESSIBLE_FROM_WITHIN_DOCKER:8089/" \
+      -e "s/data-query:80/$HOST_ACCESSIBLE_FROM_WITHIN_DOCKER:8090/" \
+      $DEV_CONF
+fi
 
 IMAGE_NAME=health-api-kong:local
 docker build -t $IMAGE_NAME .


### PR DESCRIPTION
if the environment variable DEV_CONF_KEEP is set to true. This is handy when testing changes to configuration. By default `run-local.sh` will generate a new configuration based on the DQ deployment unit.

```
DEV_CONF_KEEP=true run-local.sh
```

FYI @alecbert-va @dtournour-va @jblefkove-va @dbrown-va 