### PR TITLE
Task/adq 23 patient matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The health-apis-patient-matching plugin will act as follows on any 200 series do
 
 The plugin requires two headers,
   `X-VA-ICN`- the client ICN provided internally by the health-apis-token-validator plugin.
-  `X-VA-INCLUDES-ICN` - a comma seperated string of icn's who's data is contained in the payload. This is provided, along with the payload, by the downstream service. (Ex: data-query)
+  `X-VA-INCLUDES-ICN` - The `XA-VA-INCLUDES-ICN` response header supports a comma-delimited list of ICNs in anticipation of system use-cases (e.g., clinician workflows), such that service implementations may be developed in advance of this plugin.
 
 The health-apis-patient-matching plugin uses the following rules, in order:
 
@@ -119,8 +119,12 @@ The health-apis-patient-matching plugin uses the following rules, in order:
 4. `X-VA-ICN` does not match exactly `X-VA-INCLUDES-ICN` we 403 forbidden.
 5. `X-VA-ICN` matches exactly `X-VA-INCLUDES-ICN`
 
+### NOTE:
+The health-apis-patient-matching plugin currently supports only an exact match of `X-VA-ICN` to `X-VA-INCLUDES-ICN`. This is overly protective in the case of larger scale clinician workflows, etc... Once these have a more concrete implementation/plan, this plugin will need to be revisted.
+
+
 ##### WARNING
-This plugin assumes that ICNs are unique enough to not naturally occur in text.
+The health-apis-token-protected-operation plugin assumes that ICNs are unique enough to not naturally occur in text.
 For example, the ICN 1017283132V631076 is easily recogized and replaced with
 1011537977V693883 using simple string replacement techniques.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ This plugin will request Condition?patient=123 instead. Just prior to returning 
 response,  all occurrences of patient 123 are replaced with 999 to allow links
 to continue to work.
 
+--
+## Plugin: health-apis-patient-matching
+
+This plugin will perform patient-matching validation on all downstream responses. (data-query, etc...) The plugin runs in the priority chain at priority 805, immediately
+after doppelganger but before the response transformer.
+
+The health-apis-patient-matching plugin will act as follows on any 200 series downstream response.
+(We fail through on non-200s)
+
+The plugin requires two headers,
+  `X-VA-ICN`- the client ICN provided internally by the health-apis-token-validator plugin.
+  `X-VA-INCLUDES-ICN` - a comma seperated string of icn's who's data is contained in the payload. This is provided, along with the payload, by the downstream service. (Ex: data-query)
+
+The health-apis-patient-matching plugin uses the following rules, in order:
+
+1. `X-VA-INCLUDES-ICN` is empty or missing, we 403 forbidden.
+2. `X-VA-INCLUDES-ICN` is "NONE" we know the payload is patient agnostic (empty bundle, medication, etc...) and will allow the response through
+3. `X-VA-ICN` is missing, we 403 forbidden. We don't know the clients icn. Something spooky happened.
+4. `X-VA-ICN` does not match exactly `X-VA-INCLUDES-ICN` we 403 forbidden.
+5. `X-VA-ICN` matches exactly `X-VA-INCLUDES-ICN`
 
 ##### WARNING
 This plugin assumes that ICNs are unique enough to not naturally occur in text.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         - health-apis-static-token-handler
         - health-apis-patient-registration
         - health-apis-token-protected-operation
+        - health-apis-patient-matching
       AWS_CONFIG_FOLDER: kong
       AWS_APP_NAME: kong
     ports:

--- a/kong/plugins/health-apis-doppelganger/handler.lua
+++ b/kong/plugins/health-apis-doppelganger/handler.lua
@@ -42,7 +42,9 @@ function Doppelganger:access(conf)
          -- The doppelganger ID will be stored in the context to be used later.
          -- The absence of this information indicates that no additional processing is required
          ngx.ctx.doppelganger = me
-    --     kong.service.request.set_header("X-VA-ICN", conf.target_icn)
+         -- We need to override the client ICN with the doppelganger so that
+         -- the new payload can pass verification in health-apis-patient-matching.
+         kong.service.request.set_header("X-VA-ICN", conf.target_icn)
          kong.log.info("Doppelganger " .. doppelganger .. " for " .. conf.target_icn)
          local newPath = string.gsub(kong.request.get_path(),doppelganger,conf.target_icn)
          local newQuery = string.gsub(kong.request.get_raw_query(),doppelganger,conf.target_icn)

--- a/kong/plugins/health-apis-doppelganger/handler.lua
+++ b/kong/plugins/health-apis-doppelganger/handler.lua
@@ -42,6 +42,7 @@ function Doppelganger:access(conf)
          -- The doppelganger ID will be stored in the context to be used later.
          -- The absence of this information indicates that no additional processing is required
          ngx.ctx.doppelganger = me
+    --     kong.service.request.set_header("X-VA-ICN", conf.target_icn)
          kong.log.info("Doppelganger " .. doppelganger .. " for " .. conf.target_icn)
          local newPath = string.gsub(kong.request.get_path(),doppelganger,conf.target_icn)
          local newQuery = string.gsub(kong.request.get_raw_query(),doppelganger,conf.target_icn)
@@ -65,7 +66,6 @@ function Doppelganger:body_filter(conf)
 
    local doppelganger = ctx.doppelganger
    if (doppelganger == nil) then return end
-
    local chunk, eof = ngx.arg[1], ngx.arg[2]
 
    kong.log.info("Chunk " .. chunk)

--- a/kong/plugins/health-apis-patient-matching/handler.lua
+++ b/kong/plugins/health-apis-patient-matching/handler.lua
@@ -52,7 +52,7 @@ function HealthApisPatientMatching:header_filter()
   --
   local included = kong.response.get_header("X-VA-INCLUDES-ICN")
   if (included == nil) then
-    kong.log.info("No X-VA-INCLUDES-ICN header was provided where expected.")
+    kong.log.info("MISSING X-VA-INCLUDES-ICN HEADER. CANNOT PROCEED WITH PATIENT MATCHING")
     ngx.ctx.matching_failure = true
     kong.response.set_status(403)
     return
@@ -77,7 +77,7 @@ function HealthApisPatientMatching:header_filter()
   --
   for word in string.gmatch(included, '([^,]+)') do
     if (word ~= me) then
-      kong.log.info("Mismatched ICNs. Client ICN " .. me .. " does not equal an included ICN of " .. word)
+      kong.log.info("MISMATCHING ICNs. CLIENT ICN " .. me .. " DOES NOT EQUAL INCLUDED ICN OF " .. word)
       ngx.ctx.matching_failure = true
       kong.response.set_status(403)
       return

--- a/kong/plugins/health-apis-patient-matching/handler.lua
+++ b/kong/plugins/health-apis-patient-matching/handler.lua
@@ -62,21 +62,11 @@ function HealthApisPatientMatching:header_filter()
   -- If INCLUDES-ICN header is "NONE" then
   -- patient data is NOT included in the payload.
   -- Resources like Medication which are 'patient agnostic' will provide this.
+  -- Responses like empty bundles are also 'patient agnostic'.
   -- In these cases, we are done here.
   --
   if (included == "NONE") then
     kong.log.info("The response payload is patient agnostic.")
-    return
-  end
-
-
-  --
-  -- If INCLUDES-ICN header is "EMPTY" then
-  -- patient data is NOT included in the payload.
-  -- For this case, like an empty bundle, we are done here.
-  --
-  if (included == "EMPTY") then
-    kong.log.info("The response bundle is empty.")
     return
   end
 

--- a/kong/plugins/health-apis-patient-matching/handler.lua
+++ b/kong/plugins/health-apis-patient-matching/handler.lua
@@ -75,7 +75,7 @@ function HealthApisPatientMatching:header_filter()
   -- patient data is NOT included in the payload.
   -- For this case, like an empty bundle, we are done here.
   --
-  if (included == "NONE") then
+  if (included == "EMPTY") then
     kong.log.info("The response bundle is empty.")
     return
   end

--- a/kong/plugins/health-apis-patient-matching/handler.lua
+++ b/kong/plugins/health-apis-patient-matching/handler.lua
@@ -63,7 +63,7 @@ function HealthApisPatientMatching:header_filter()
   -- Unable to verify patient-matching, we must 403 forbidden the payload.
   --
   local me = ngx.ctx.icnHeader
-  if(me == nil) then
+  if (me == nil) then
     kong.log.info("MISSING X-VA-ICN HEADER. CANNOT PROCEED WITH PATIENT MATCHING.")
     ngx.ctx.matching_failure = true
     kong.response.set_status(403)

--- a/kong/plugins/health-apis-patient-matching/handler.lua
+++ b/kong/plugins/health-apis-patient-matching/handler.lua
@@ -1,0 +1,87 @@
+local HealthApisPatientMatching = require("kong.plugins.base_plugin"):extend()
+
+function HealthApisPatientMatching:new()
+   HealthApisPatientMatching.super.new(self,"health-apis-patient-matching")
+end
+
+--
+-- Remember our internal X-VA-ICN header values for later use
+--
+function HealthApisPatientMatching:access(conf)
+  HealthApisPatientMatching.super.access(self)
+  local me = kong.request.get_header("X-VA-ICN")
+  if (me == nil) then return end
+  kong.log.info("Receiving X-VA-ICN Header as: " .. me)
+  ngx.ctx.icnHeader = me
+end
+
+--
+-- Compare the values of the X-VA-ICN header to that of the X-VA-INCLUDES-ICNS headers
+-- If they match, allow the response through.
+-- If there is a mismatch, response with error code 403 Forbidden.
+--
+function HealthApisPatientMatching:header_filter(conf)
+  local me = ngx.ctx.icnHeader
+  local included = kong.response.get_header("X-VA-INCLUDES-ICN")
+  if (included == nil) then
+    kong.log.info("No X-VA-INCLUDES-ICN header was provided.")
+    ngx.ctx.matching = "MISSING"
+  end
+  for word in string.gmatch(included, '([^,]+)') do
+    if (word ~= me) then
+      kong.log.info("Mismatched ICNs. Client ICN " .. me .. " does not equal an included ICN of " .. word)
+      ngx.ctx.matching = "MISMATCHED"
+    end
+  kong.log.info("Matching ICNs. Client ICN " .. me .. " does equals the included ICN of " .. word)
+  end
+end
+
+function HealthApisPatientMatching:body_filter(conf)
+  HealthApisPatientMatching.super.body_filter(self)
+  self.conf = conf
+
+  local result = ngx.ctx.matching
+  kong.log.info("MATCHING STATE: " .. result)
+  if (result == nil) then return end
+  if (result == "MISSING") then
+    self.sendOperationOutcome(400, "Missing ICN.")
+  end
+  if (result == "MISMATCH") then
+    self.sendOperationOutcome(403, "Token not allowed access to this patient.")
+  end
+end
+
+--
+-- Sends an operationOutcome to the user with a given status code and message value
+--
+function HealthApisPatientMatching:sendOperationOutcome(statusCode, message)
+  local OPERATIONAL_OUTCOME_TEMPLATE =
+    '{ "resourceType": "OperationOutcome",\n' ..
+    '  "id": "exception",\n' ..
+    '  "text": {\n' ..
+    '      "status": "additional",\n' ..
+    '      "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><p>%s</p></div>"\n' ..
+    '  },\n' ..
+    '  "issue": [\n' ..
+    '      {\n' ..
+    '          "severity": "error",\n' ..
+    '          "code": "exception",\n' ..
+    '          "details": {\n' ..
+    '              "text": "%s"\n' ..
+    '          }\n' ..
+    '      }\n' ..
+    '  ]\n' ..
+    '}'
+
+    kong.log.info("Responding with " .. statusCode .. ":" .. message)
+    ngx.status = statusCode
+    ngx.header["Content-Type"] = "application/json"
+
+    ngx.say(string.format(OPERATIONAL_OUTCOME_TEMPLATE, message, message))
+
+    ngx.exit(statusCode)
+
+-- end of HealthApisPatientMatching:SendOperationOutcome()
+end
+
+return HealthApisPatientMatching;

--- a/kong/plugins/health-apis-patient-matching/schema.lua
+++ b/kong/plugins/health-apis-patient-matching/schema.lua
@@ -3,9 +3,9 @@ return {
   --
   -- THIS IS A SAD HACK!
   -- The plug-in will not compile if the fields object is left null. BOOOOOOO!
-  -- We initialize a dummy value that we never use.
+  -- We don't actually need this, but lets initialize a dummy value that we never use.
   --
   fields = {
-    UNUSED = {type = "boolean", default = false}
+    UNUSED = {type = "boolean", default = true}
   }
 }

--- a/kong/plugins/health-apis-patient-matching/schema.lua
+++ b/kong/plugins/health-apis-patient-matching/schema.lua
@@ -1,0 +1,6 @@
+return {
+  no_consumer = true,
+  fields = {
+    some_boolean = {type = "boolean", default = false}
+  }
+}

--- a/kong/plugins/health-apis-patient-matching/schema.lua
+++ b/kong/plugins/health-apis-patient-matching/schema.lua
@@ -1,6 +1,11 @@
 return {
   no_consumer = true,
+  --
+  -- THIS IS A SAD HACK!
+  -- The plug-in will not compile if the fields object is left null. BOOOOOOO!
+  -- We initialize a dummy value that we never use.
+  --
   fields = {
-    some_boolean = {type = "boolean", default = false}
+    UNUSED = {type = "boolean", default = false}
   }
 }

--- a/run-local.sh
+++ b/run-local.sh
@@ -67,7 +67,7 @@ docker build -t $IMAGE_NAME .
 PLUGIN_ARRAY=('request-termination' 'response-transformer' \
   'health-apis-token-validator' 'health-apis-static-token-handler' \
   'health-apis-patient-registration' 'health-apis-doppelganger' \
-  'health-apis-token-protected-operation')
+  'health-apis-token-protected-operation' 'health-apis-patient-matching')
 
 docker run \
   --rm \


### PR DESCRIPTION
# **FINE... MERGE IT... I DONT CARE**

Patient matching implementation.
- New health-apis-patient-matching plugin
- Doppelgangers now update the X-VA-ICN with the doppelganger_target icn
- patient-matching priority (805) fires between doppelganger (810) and response-transformer plugins (800)

This is the second half of the patient matching implementation. 
See [PR](https://github.com/department-of-veterans-affairs/health-apis-data-query/pull/342) for the DQ implementation.

Data-query will provide a new header in responses, <X-VA-INCLUDES-ICN> which is a comma delimited list of the patient(s) associated to the data in the payload, or "NONE" in the case of patient-agnostic data.

The health-apis-patient-matching plugin will act as follows on any 200 series downstream response.
(We fail through on non-200s)

The health-apis-patient-matching plugin uses the following rules, in order:

1. `X-VA-INCLUDES-ICN` is empty or missing, we 403 forbidden.
2. `X-VA-INCLUDES-ICN` is "NONE" we know the payload is patient agnostic (empty bundle, medication, etc...) and will allow the response through
3. `X-VA-ICN` is missing, we 403 forbidden. We don't know the clients icn. Something spooky happened.
4. `X-VA-ICN` does not match exactly `X-VA-INCLUDES-ICN` we 403 forbidden.
5. `X-VA-ICN` matches exactly `X-VA-INCLUDES-ICN`


New Kong.yaml in DQ-Deployment. Use this for local testing. You need to turn on the new plugin.

You can use this branch to test,

https://github.com/department-of-veterans-affairs/health-apis-data-query-deployment/tree/task/ADQ-23-kong-patient-matching-plugin

or do it yourself,

```
--- a/s3/kong/kong.yml
+++ b/s3/kong/kong.yml
@@ -20,6 +20,7 @@ services:
         api_key: $KONG_API_KEY
         static_token: $KONG_STATIC_ACCESS_TOKEN
         static_icn: 1011537977V693883
+    - name: health-apis-patient-matching
     - name: health-apis-token-protected-operation
       config:
         request_header_key: $KONG_REQUEST_HEADER_KEY
@@ -32,6 +33,9 @@ services:
           headers:
             - 'Pragma: no-cache'
             - 'Cache-Control: no-cache, no-store'
+        remove:
+          headers:
+            - "X-VA-INCLUDES-ICN"
   - name: argonaut-token-route
     paths:
     - /token
```