### PR TITLE
Task/shank 121 request transformer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       KONG_PLUGINS:
         - request-termination
         - response-transformer
+        - request-transformer
         - health-apis-token-validator
         - health-apis-static-token-handler
         - health-apis-patient-registration

--- a/run-local.sh
+++ b/run-local.sh
@@ -133,7 +133,8 @@ docker build -t $IMAGE_NAME .
 PLUGIN_ARRAY=('request-termination' 'response-transformer' \
   'health-apis-token-validator' 'health-apis-static-token-handler' \
   'health-apis-patient-registration' 'health-apis-doppelganger' \
-  'health-apis-token-protected-operation' 'health-apis-patient-matching')
+  'health-apis-token-protected-operation' 'health-apis-patient-matching' \
+  'request-transformer')
 
 docker run \
   --rm \


### PR DESCRIPTION
[SHANK-121](https://vasdvp.atlassian.net/browse/SHANK-121)

When requests are forwarded from Kong to S3 (occurs when requesting an S3 file in bulk-fhir kong.yml) the `Authorization` header is forwarded to the S3.
S3 is not a fan of this and returns `400 - bad request` as a response. With this plugin, we will remove the `Authorization` header so it is not forwarded to S3. 

FYI @beaugrantham-va @jblefkove-va 